### PR TITLE
Retirando a coluna das senhas da lista dos usuários cadstrados

### DIFF
--- a/itaretif/src/main/resources/templates/adm/lista.html
+++ b/itaretif/src/main/resources/templates/adm/lista.html
@@ -48,7 +48,6 @@
 					<th>ID:</th>
 					<th>Nome:</th>
 					<th>Matrícula:</th>
-					<th>Senha:</th>
 					<th>Ações</th>
 							
 				</tr>
@@ -58,7 +57,6 @@
 					<td><samp th:text= ${usuario.id}></samp></td>
 					<td><a th:href="${(#mvc.url('AC#detalharUsuario').arg(0, usuario.matricula)).build()}"><samp th:text= ${usuario.nome}></samp></a></td>
 					<td><samp th:text= ${usuario.matricula}></samp></td>
-					<td><samp th:text= ${usuario.senha}></samp></td>
 					<td>
 						<a th:href="@{/editarUsuario/{matricula}(matricula=${usuario.matricula})}">
 							<button type="button" class="btn btn-outline-success" style="border-color: #25A25A!important;">

--- a/itaretif/src/main/resources/templates/adm/usuarioDetalhes.html
+++ b/itaretif/src/main/resources/templates/adm/usuarioDetalhes.html
@@ -34,7 +34,6 @@
 					<th>ID:</th>
 					<th>Nome:</th>
 					<th>Matrícula:</th>
-					<th>Senha:</th>
 					<th>Papel</th>
 							
 				</tr>
@@ -44,7 +43,6 @@
 					<td><samp th:text= ${usuario.id}></samp></td>
 					<td><samp th:text= ${usuario.nome}></samp></td>
 					<td><samp th:text= ${usuario.matricula}></samp></td>
-					<td><samp th:text= ${usuario.senha}></samp></td>
 <!-- 					<td><samp th:text= ${usuario.roles}></samp></td>	 -->
 				</tr>
 			</tbody>


### PR DESCRIPTION
Por orientação, retirei os inputs para mostrar a senha do usuário cadastrado tanto na lista de usuários (amd/lista.html) quanto na página com o detalhamento do usuário (adm/usuarioDetalhes.html).